### PR TITLE
Implement SSE chat with retrieval and namespace scoping

### DIFF
--- a/backend/app/api/routes_chat.py
+++ b/backend/app/api/routes_chat.py
@@ -1,10 +1,244 @@
 """Chat endpoints for the RAG assistant."""
-from fastapi import APIRouter
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, AsyncIterator, Dict, Iterable, List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from ..core.config import settings
+from ..core.db import SessionLocal, get_session
+from ..models import Conversation, Message, NamespaceMember
+from ..rag import ollama_client, retrieval
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+SYSTEM_PROMPT = (
+    "You are the Heidelberg University IT support assistant. "
+    "Use only the provided knowledge base excerpts to answer user questions. "
+    "If the answer is not contained in the context, reply that you do not know. "
+    "When you reference information from a context snippet include a footnote marker in the form [^N] where N matches the source number."
+)
 
-@router.post("/", summary="Chat completion")
-async def chat_completion() -> dict[str, str]:
-    """Placeholder endpoint for chat responses."""
-    return {"message": "Chat endpoint stub"}
+
+class ChatStartRequest(BaseModel):
+    namespace_id: uuid.UUID = Field(..., description="Namespace containing the knowledge base")
+    conversation_id: uuid.UUID | None = Field(
+        default=None, description="Optional existing conversation identifier"
+    )
+
+
+class ChatStartResponse(BaseModel):
+    conversation_id: uuid.UUID
+
+
+class _CitationPayload(BaseModel):
+    doc_id: uuid.UUID
+    ord: int
+    title: str | None = None
+    chunk_id: uuid.UUID | None = None
+    text: str | None = None
+
+
+def _require_user_id(request: Request) -> uuid.UUID:
+    raw_user_id = getattr(request.state, "user_id", None)
+    if not raw_user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    try:
+        return uuid.UUID(str(raw_user_id))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session") from exc
+
+
+def _assert_namespace_membership(session: Session, namespace_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    stmt: Select[Any] = select(NamespaceMember.id).where(
+        NamespaceMember.namespace_id == namespace_id,
+        NamespaceMember.user_id == user_id,
+    )
+    exists = session.execute(stmt).scalar_one_or_none()
+    if exists is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Namespace access denied")
+
+
+@router.post("/start", response_model=ChatStartResponse, summary="Ensure a conversation exists")
+async def chat_start(
+    payload: ChatStartRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> ChatStartResponse:
+    """Create a conversation within the namespace if needed."""
+
+    user_id = _require_user_id(request)
+    _assert_namespace_membership(session, payload.namespace_id, user_id)
+
+    if payload.conversation_id:
+        conversation = session.get(Conversation, payload.conversation_id)
+        if (
+            conversation is None
+            or conversation.namespace_id != payload.namespace_id
+            or (conversation.user_id and conversation.user_id != user_id)
+        ):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+        return ChatStartResponse(conversation_id=conversation.id)
+
+    conversation = Conversation(namespace_id=payload.namespace_id, user_id=user_id)
+    session.add(conversation)
+    session.flush()
+    return ChatStartResponse(conversation_id=conversation.id)
+
+
+def _load_recent_messages(session: Session, conversation_id: uuid.UUID) -> List[Message]:
+    stmt = (
+        select(Message)
+        .where(Message.conversation_id == conversation_id)
+        .order_by(Message.created_at.desc())
+        .limit(settings.CHAT_HISTORY_LIMIT)
+    )
+    rows = session.execute(stmt).scalars().all()
+    return list(reversed(rows))
+
+
+def _build_context(chunks: Iterable[retrieval.RetrievedChunk]) -> tuple[str, List[_CitationPayload]]:
+    context_lines: List[str] = []
+    citations: List[_CitationPayload] = []
+    for idx, chunk in enumerate(chunks, start=1):
+        title = chunk.title or "Untitled document"
+        context_lines.append(f"[{idx}] {title}\n{chunk.text.strip()}")
+        citations.append(
+            _CitationPayload(
+                doc_id=chunk.document_id,
+                ord=chunk.ordinal,
+                title=chunk.title,
+                chunk_id=chunk.chunk_id,
+                text=chunk.text,
+            )
+        )
+    context = "\n\n".join(context_lines) if context_lines else "(no supporting context found)"
+    return context, citations
+
+
+def _format_history(messages: Iterable[Message], latest_user_input: str) -> str:
+    lines: List[str] = []
+    for message in messages:
+        role = "User" if message.role == "user" else "Assistant"
+        content = message.content.strip()
+        if not content:
+            continue
+        lines.append(f"{role}: {content}")
+    lines.append(f"User: {latest_user_input.strip()}")
+    lines.append("Assistant:")
+    return "\n".join(lines)
+
+
+def _sse_payload(data: Dict[str, Any]) -> str:
+    return f"data: {json.dumps(data, default=str)}\n\n"
+
+
+@router.get("/stream", summary="Stream chat completions over SSE")
+async def chat_stream(
+    request: Request,
+    conversation_id: uuid.UUID = Query(...),
+    namespace_id: uuid.UUID = Query(...),
+    q: str = Query(..., min_length=1),
+) -> StreamingResponse:
+    """Handle a chat turn by retrieving context and streaming model tokens."""
+
+    user_id = _require_user_id(request)
+    question = q.strip()
+    if not question:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empty query")
+
+    session = SessionLocal()
+    try:
+        conversation = session.get(Conversation, conversation_id)
+        if conversation is None or conversation.namespace_id != namespace_id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+        if conversation.user_id and conversation.user_id != user_id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Conversation access denied")
+
+        _assert_namespace_membership(session, namespace_id, user_id)
+
+        history = _load_recent_messages(session, conversation_id)
+
+        retrieved_chunks = retrieval.retrieve(question, namespace_id, session=session)
+        context, citations = _build_context(retrieved_chunks)
+
+        conversation.updated_at = datetime.now(timezone.utc)
+        if not conversation.title:
+            conversation.title = question[:80]
+
+        message = Message(
+            conversation_id=conversation.id,
+            user_id=user_id,
+            role="user",
+            content=question,
+        )
+        session.add(message)
+        session.commit()
+    finally:
+        session.close()
+
+    prompt = "\n\n".join(
+        [
+            SYSTEM_PROMPT,
+            "Context:",
+            context,
+            "Conversation:",
+            _format_history(history, question),
+        ]
+    )
+
+    async def event_stream() -> AsyncIterator[str]:
+        assistant_reply: List[str] = []
+        try:
+            async for chunk in ollama_client.stream_generate(prompt):
+                token = chunk.get("response") or chunk.get("token")
+                if token:
+                    assistant_reply.append(token)
+                    yield _sse_payload({"token": token})
+                if chunk.get("done"):
+                    break
+        except Exception:
+            logger.exception("Ollama streaming failure")
+            yield _sse_payload({"done": True, "error": "model_error"})
+            return
+
+        payload = {
+            "done": True,
+            "citations": [citation.model_dump() for citation in citations],
+        }
+        yield _sse_payload(payload)
+
+        response_text = "".join(assistant_reply).strip()
+        with SessionLocal() as write_session:
+            conversation = write_session.get(Conversation, conversation_id)
+            if conversation is None:
+                return
+            conversation.updated_at = datetime.now(timezone.utc)
+            assistant_message = Message(
+                conversation_id=conversation.id,
+                user_id=None,
+                role="assistant",
+                content=response_text,
+            )
+            assistant_message.metadata = {
+                "citations": [citation.model_dump() for citation in citations]
+            }
+            write_session.add(assistant_message)
+            write_session.commit()
+
+    headers = {
+        "Cache-Control": "no-cache",
+        "Content-Type": "text/event-stream",
+        "Connection": "keep-alive",
+    }
+    return StreamingResponse(event_stream(), headers=headers, media_type="text/event-stream")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,6 +25,10 @@ class Settings(BaseSettings):
     EMBEDDING_MODEL_NAME: str = Field(default="sentence-transformers/all-MiniLM-L6-v2")
     EMBEDDING_DIM: int = Field(default=1536)
 
+    RETRIEVAL_TOP_K: int = Field(default=5)
+    RETRIEVAL_USE_RERANKER: bool = Field(default=False)
+    RERANKER_CANDIDATE_MULTIPLIER: int = Field(default=3)
+
     OIDC_CLIENT_ID: str = Field(default="client-id")
     OIDC_CLIENT_SECRET: str = Field(default="client-secret")
     OIDC_ISSUER: str = Field(default="https://example.com/oidc")
@@ -37,6 +41,10 @@ class Settings(BaseSettings):
     SESSION_COOKIE_SECURE: bool = Field(default=True)
 
     OLLAMA_HOST: str = Field(default="http://ollama:11434")
+    OLLAMA_MODEL: str = Field(default="gpt-oss-20b")
+    OLLAMA_TIMEOUT: float = Field(default=120.0)
+
+    CHAT_HISTORY_LIMIT: int = Field(default=12)
 
     model_config = {
         "env_file": ".env",

--- a/backend/app/rag/ollama_client.py
+++ b/backend/app/rag/ollama_client.py
@@ -1,16 +1,51 @@
-"""HTTP client for interacting with Ollama."""
+"""HTTP client helpers for interacting with a local Ollama instance."""
 from __future__ import annotations
 
-from typing import Any, Dict
+import json
+from typing import Any, AsyncIterator, Dict, Optional
 
 import httpx
 
 from ..core.config import settings
 
 
-async def generate(prompt: str) -> Dict[str, Any]:
-    """Call the Ollama API with a prompt and return the response."""
-    async with httpx.AsyncClient(base_url=settings.OLLAMA_HOST) as client:
-        response = await client.post("/api/generate", json={"prompt": prompt})
-        response.raise_for_status()
-        return response.json()
+async def stream_generate(
+    prompt: str,
+    *,
+    model: str | None = None,
+    options: Optional[Dict[str, Any]] = None,
+) -> AsyncIterator[Dict[str, Any]]:
+    """Stream tokens from Ollama's generate endpoint."""
+
+    payload: Dict[str, Any] = {
+        "model": model or settings.OLLAMA_MODEL,
+        "prompt": prompt,
+        "stream": True,
+    }
+    if options:
+        payload["options"] = options
+
+    async with httpx.AsyncClient(base_url=settings.OLLAMA_HOST, timeout=settings.OLLAMA_TIMEOUT) as client:
+        async with client.stream("POST", "/api/generate", json=payload) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                yield data
+
+
+async def complete(prompt: str, *, model: str | None = None) -> str:
+    """Convenience helper returning the full generated text."""
+
+    tokens: list[str] = []
+    async for chunk in stream_generate(prompt, model=model):
+        token = chunk.get("response") or chunk.get("token")
+        if token:
+            tokens.append(token)
+        if chunk.get("done"):
+            break
+    return "".join(tokens)

--- a/backend/app/rag/ranker.py
+++ b/backend/app/rag/ranker.py
@@ -1,9 +1,29 @@
-"""Result ranking utilities."""
+"""Lightweight reranking utilities for retrieval results."""
 from __future__ import annotations
 
-from typing import Iterable, List
+import re
+from typing import List, Sequence, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid only
+    from .retrieval import RetrievedChunk
 
 
-def rerank(results: Iterable[str]) -> List[str]:
-    """Placeholder reranker returning the input order."""
-    return list(results)
+def rerank(query: str, results: Sequence["RetrievedChunk"]) -> List["RetrievedChunk"]:
+    """Sort results using a simple lexical overlap heuristic."""
+
+    terms = {
+        token.lower()
+        for token in re.findall(r"\w+", query)
+        if token and token.lower() not in {"the", "a", "an"}
+    }
+    if not terms:
+        return list(results)
+
+    def overlap_score(chunk: "RetrievedChunk") -> tuple[int, float]:
+        text = chunk.text.lower()
+        matches = sum(1 for term in terms if term in text)
+        # Lower ANN score is better; return as secondary key
+        return matches, -chunk.score
+
+    sorted_results = sorted(results, key=overlap_score, reverse=True)
+    return sorted_results

--- a/backend/app/rag/retrieval.py
+++ b/backend/app/rag/retrieval.py
@@ -1,9 +1,110 @@
-"""Retrieval orchestration stubs."""
+"""Vector retrieval utilities used by the chat endpoints."""
 from __future__ import annotations
 
-from typing import Iterable, List
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from ..core.config import settings
+from ..ingest import embeddings
+from ..models import Chunk, Document
+from ..models.documents import DocumentStatus
+from . import ranker
+
+logger = logging.getLogger(__name__)
 
 
-def retrieve(query: str, namespace: str) -> List[str]:
-    """Placeholder retrieval returning canned responses."""
-    return [f"Result for {query} in {namespace}"]
+@dataclass(slots=True)
+class RetrievedChunk:
+    """Lightweight representation of a retrieved chunk."""
+
+    chunk_id: uuid.UUID
+    document_id: uuid.UUID
+    text: str
+    score: float
+    ordinal: int
+    title: str | None
+    metadata: dict | None
+
+
+def _build_query_statement(vector: Sequence[float], namespace_id: uuid.UUID, limit: int) -> Select:
+    """Return the base statement for a similarity search."""
+
+    distance = Chunk.vector.cosine_distance(vector)
+    stmt = (
+        select(
+            Chunk.id.label("chunk_id"),
+            Chunk.document_id.label("document_id"),
+            Chunk.text.label("text"),
+            Chunk.metadata.label("metadata"),
+            Chunk.ordinal.label("ordinal"),
+            Document.title.label("title"),
+            distance.label("distance"),
+        )
+        .join(Document, Document.id == Chunk.document_id)
+        .where(
+            Chunk.namespace_id == namespace_id,
+            Chunk.vector.isnot(None),
+            Document.status == DocumentStatus.INGESTED.value,
+            Document.deleted_at.is_(None),
+        )
+        .order_by(distance)
+        .limit(limit)
+    )
+    return stmt
+
+
+def retrieve(
+    query: str,
+    namespace_id: uuid.UUID,
+    *,
+    session: Session,
+    top_k: int | None = None,
+) -> List[RetrievedChunk]:
+    """Embed the query, run ANN search, and optionally rerank results."""
+
+    search_text = query.strip()
+    if not search_text:
+        return []
+
+    vectors = embeddings.embed([search_text])
+    if not vectors:
+        logger.debug("Embedding model returned no vector for query")
+        return []
+
+    target_top_k = max(top_k or settings.RETRIEVAL_TOP_K, 1)
+    candidate_multiplier = (
+        settings.RERANKER_CANDIDATE_MULTIPLIER if settings.RETRIEVAL_USE_RERANKER else 1
+    )
+    candidate_limit = max(target_top_k * candidate_multiplier, target_top_k)
+
+    stmt = _build_query_statement(vectors[0], namespace_id, candidate_limit)
+    rows = session.execute(stmt).all()
+
+    results: List[RetrievedChunk] = [
+        RetrievedChunk(
+            chunk_id=row.chunk_id,
+            document_id=row.document_id,
+            text=row.text,
+            score=float(row.distance or 0.0),
+            ordinal=int(row.ordinal or 0),
+            title=row.title,
+            metadata=row.metadata if isinstance(row.metadata, dict) else None,
+        )
+        for row in rows
+    ]
+
+    if not results:
+        return []
+
+    if settings.RETRIEVAL_USE_RERANKER:
+        try:
+            results = ranker.rerank(search_text, results)
+        except Exception:  # pragma: no cover - safety net
+            logger.exception("Reranker failed; falling back to ANN ordering")
+
+    return results[:target_top_k]

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,9 +1,14 @@
-import { useState } from 'react'
+import { useState, ChangeEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useAuth } from '../context/AuthContext'
 
-export default function Navbar() {
+type Props = {
+  selectedNamespaceId: string | null
+  onNamespaceChange: (namespaceId: string) => void
+}
+
+export default function Navbar({ selectedNamespaceId, onNamespaceChange }: Props) {
   const { user, namespaces, logout } = useAuth()
   const navigate = useNavigate()
   const [pending, setPending] = useState(false)
@@ -18,7 +23,12 @@ export default function Navbar() {
     }
   }
 
-  const namespace = namespaces[0]
+  const namespace = namespaces.find((ns) => ns.id === selectedNamespaceId) || namespaces[0] || null
+
+  const handleNamespaceChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value
+    onNamespaceChange(value)
+  }
 
   return (
     <nav className="flex w-full flex-col gap-2 bg-white/90 px-4 py-3 text-sm text-gray-700 shadow md:flex-row md:items-center md:justify-between">
@@ -26,7 +36,19 @@ export default function Navbar() {
         <span className="font-medium text-gray-800">
           {user?.displayName || user?.email || 'Authenticated User'}
         </span>
-        {namespace && <span className="text-gray-500">{namespace.name}</span>}
+        {namespaces.length > 0 && (
+          <select
+            value={namespace?.id || ''}
+            onChange={handleNamespaceChange}
+            className="mt-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs text-gray-600 shadow-sm md:mt-0"
+          >
+            {namespaces.map((ns) => (
+              <option key={ns.id} value={ns.id}>
+                {ns.name}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
       <button
         onClick={handleLogout}

--- a/frontend/src/components/ResponseDisplay.tsx
+++ b/frontend/src/components/ResponseDisplay.tsx
@@ -12,10 +12,19 @@ declare global {
   }
 }
 
+export interface Citation {
+  docId: string
+  ord: number
+  title: string | null
+  chunkId?: string | null
+  text?: string | null
+}
+
 export interface Message {
-  sender: "user" | "bot";
-  text: unknown;
-  think?: string;
+  sender: "user" | "bot"
+  text: unknown
+  think?: string
+  citations?: Citation[]
 }
 
 type Props = {
@@ -23,6 +32,7 @@ type Props = {
   loading: boolean;
   onSelectThinking: (think: string) => void;
   thinkingEnabled: boolean;
+  onSelectCitation?: (citation: Citation) => void;
 };
 
 function toStr(v: unknown) {
@@ -122,6 +132,7 @@ export default function ResponseDisplay({
   loading,
   onSelectThinking,
   thinkingEnabled,
+  onSelectCitation,
 }: Props) {
   const [libsReady, setLibsReady] = useState(
     !!(window.marked && window.DOMPurify)
@@ -175,10 +186,32 @@ export default function ResponseDisplay({
             }`}
             dangerouslySetInnerHTML={{ __html: m.__html }}
           />
+          {m.sender === "bot" && Array.isArray(m.citations) && m.citations.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {m.citations.map((citation: Citation, idx: number) => (
+                <button
+                  key={`${citation.docId}-${citation.ord}-${idx}`}
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onSelectCitation?.(citation)
+                  }}
+                  className="citation-badge"
+                >
+                  <span className="font-semibold">Source {idx + 1}</span>
+                  {citation.title && (
+                    <span className="ml-1 truncate text-xs text-gray-600">
+                      {citation.title}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       ))}
 
-            {loading && (
+      {loading && (
         <div className="flex justify-center py-2">
           <svg
             className="animate-spin h-6 w-6 text-gray-500"

--- a/frontend/src/components/SourceSidebar.tsx
+++ b/frontend/src/components/SourceSidebar.tsx
@@ -1,0 +1,45 @@
+import type { Citation } from './ResponseDisplay'
+
+type Props = {
+  citation: Citation
+  onClose: () => void
+}
+
+export default function SourceSidebar({ citation, onClose }: Props) {
+  const ordinal = Number.isFinite(citation.ord) ? citation.ord + 1 : citation.ord
+  return (
+    <div className="sidebar h-[70vh] flex flex-col">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-gray-800">Source Details</h3>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-full bg-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-300"
+        >
+          Close
+        </button>
+      </div>
+      <div className="space-y-2 text-sm text-gray-700">
+        <div>
+          <span className="font-semibold text-gray-900">Title:</span>{' '}
+          <span>{citation.title || 'Untitled document'}</span>
+        </div>
+        <div className="break-all text-xs text-gray-500">
+          <span className="font-semibold text-gray-700">Document ID:</span>{' '}
+          {citation.docId}
+        </div>
+        {ordinal !== null && ordinal !== undefined && (
+          <div className="text-xs text-gray-500">
+            <span className="font-semibold text-gray-700">Section:</span>{' '}
+            {ordinal}
+          </div>
+        )}
+      </div>
+      {citation.text && (
+        <div className="mt-4 flex-1 overflow-y-auto rounded-lg bg-white p-4 text-sm shadow-inner">
+          <pre className="whitespace-pre-wrap font-sans text-gray-800">{citation.text}</pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -110,6 +110,26 @@ body::before {
   word-break: break-all;
 }
 
+.citation-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(229, 231, 235, 1);
+  background: #f9fafb;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  color: #374151;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.citation-badge:hover {
+  background: #f3f4f6;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
+}
+
 
 /* Tables */
 .chat-markdown table { width: 100%; border-collapse: collapse; margin: 0.75rem 0; }


### PR DESCRIPTION
## Summary
- replace the chat stubs with a streaming `/api/chat/stream` SSE endpoint that performs namespace-scoped ANN retrieval, optional reranking, and streams Ollama tokens with citation metadata while persisting conversation history
- expose a `/api/chat/start` helper for conversation creation, expand configuration for retrieval, reranking, and Ollama, and add a streaming client for the local Ollama model
- overhaul the front-end chat experience with namespace selection, SSE consumption, live streaming updates, and citation badges that open a source sidebar

## Testing
- pytest
- npm install *(fails: 403 Forbidden fetching packages from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d3813b95188322bcad32956940441d