### PR TITLE
Use host-provided Ollama daemon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@ MINIO_BUCKET=rag-data
 OIDC_CLIENT_ID=changeme
 OIDC_CLIENT_SECRET=changeme
 OIDC_ISSUER=https://example.com/oidc
-OLLAMA_HOST=http://ollama:11434
+OLLAMA_HOST=http://host.docker.internal:11434

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cp .env.example .env
 ```
 
 The defaults target local containers: PostgreSQL with the pgvector extension, Redis, MinIO,
-and an Ollama runtime.
+and expect an Ollama runtime to be available on the Docker host.
 
 ### 2. Build Images
 
@@ -71,7 +71,11 @@ The command starts the following services:
 | `db`       | PostgreSQL 16 with pgvector extension  | 5432 |
 | `redis`    | Redis message broker / cache           | 6379 |
 | `minio`    | S3-compatible object storage           | 9000 (API), 9001 (console) |
-| `ollama`   | Local model runtime                    | 11434 |
+
+> **Note**
+> Start `ollama serve` (or ensure another Ollama daemon is listening on port 11434) on the
+> host machine before launching Docker Compose. The containers reach it through
+> `http://host.docker.internal:11434`.
 
 ### 4. Smoke Test
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
     SESSION_COOKIE_NAME: str = Field(default="rag_session")
     SESSION_COOKIE_SECURE: bool = Field(default=True)
 
-    OLLAMA_HOST: str = Field(default="http://ollama:11434")
+    OLLAMA_HOST: str = Field(default="http://host.docker.internal:11434")
     OLLAMA_MODEL: str = Field(default="gpt-oss-20b")
     OLLAMA_TIMEOUT: float = Field(default=120.0)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   api:
     build:
@@ -9,11 +7,12 @@ services:
     env_file: .env
     ports:
       - "8000:8000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - db
       - redis
       - minio
-      - ollama
     volumes:
       - ./:/app
 
@@ -27,7 +26,8 @@ services:
       - db
       - redis
       - minio
-      - ollama
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./:/app
 
@@ -70,14 +70,6 @@ services:
     volumes:
       - minio-data:/data
 
-  ollama:
-    image: ollama/ollama:0.3.12
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama-models:/root/.ollama
-
 volumes:
   pgdata:
   minio-data:
-  ollama-models:


### PR DESCRIPTION
## Summary
- remove the Ollama container from docker-compose and point the API and worker containers at the host daemon via host.docker.internal
- update environment defaults and documentation to reflect the expectation of an external Ollama service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ab5b30388322881f52d80d7d41f6