### PR TITLE
Update branding and enable local login

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
 
     SESSION_SECRET: str = Field(default="change-me")
     SESSION_COOKIE_NAME: str = Field(default="rag_session")
-    SESSION_COOKIE_SECURE: bool = Field(default=True)
+    SESSION_COOKIE_SECURE: bool = Field(default=False)
 
     LOCAL_LOGIN_ENABLED: bool = Field(default=True)
     LOCAL_LOGIN_EMAIL: str = Field(default="test@uni-heidelberg.de")

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useAuth } from '../context/AuthContext'
 import logo from '/imgs/logo.png'
-import chatbotLogo from '/imgs/chatbot_logo.png'
+import chatbotLogo from '/imgs/chatbot_psy.png'
 import QueryInterface from './QueryInterface'
 import ResponseDisplay, {
   type Message as DisplayMessage,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -177,10 +177,11 @@ body::before {
 }
 
 .login-logo {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #b51234;
-  letter-spacing: 0.08em;
+  display: block;
+  height: 64px;
+  width: auto;
+  margin: 0 auto;
+  object-fit: contain;
 }
 
 .login-subtitle {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom'
 
 import { useAuth } from '../context/AuthContext'
 
+import chatbotLogo from '/imgs/chatbot_psy.png'
+
 export default function Login() {
   const { user, loading, refresh } = useAuth()
   const navigate = useNavigate()
@@ -59,7 +61,7 @@ export default function Login() {
     <div className="login-page">
       <div className="login-card">
         <header className="login-header">
-          <div className="login-logo">heiBOX</div>
+          <img src={chatbotLogo} alt="Chatbot Psy" className="login-logo" />
           <div className="login-subtitle">Universitätsrechenzentrum Heidelberg</div>
         </header>
         <main>


### PR DESCRIPTION
## Summary
- switch the home and login pages to use the chatbot psy logo asset
- adjust the login page header styling to accommodate the image-based logo
- disable secure-only cookies by default so the local test password works over HTTP

## Testing
- pytest backend
- npm install *(fails: registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d3dfdf5d3083229969a0f544e06066