### PR TITLE
Run database migrations automatically before backend services start

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -12,4 +12,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend ./backend
 
+RUN chmod +x backend/scripts/start.sh
+
+ENTRYPOINT ["./backend/scripts/start.sh"]
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ curl http://localhost:8000/admin/health
 # {"status":"ok"}
 ```
 
+For a fresh stack this also exercises the database migrations that run at container start. The
+development login is enabled by default, so you can request a session cookie with the bundled
+credentials:
+
+```bash
+curl -i -X POST http://localhost:8000/auth/local-login \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "test@uni-heidelberg.de", "password": "testtest"}'
+```
+
+The response should return `HTTP/1.1 200 OK` and include the `rag_session` and `csrf_token`
+cookies.
+
 You can then visit the chat UI at [http://localhost:3000](http://localhost:3000).
 
 ### 5. Run the test suite
@@ -97,6 +110,22 @@ The backend exposes a focused pytest suite. After installing the requirements fr
 cd backend
 pytest
 ```
+
+## Running the backend without Docker
+
+When you want to run Uvicorn directly on the host (for example while iterating on code with
+hot-reload), apply the Alembic migrations before starting the server so the database schema matches
+the models:
+
+```bash
+cd backend
+alembic upgrade head
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+The command uses the defaults from `backend/alembic.ini`; set the same environment variables as the
+Docker Compose stack (`cp .env.example .env` and source the values you need) so the API can connect
+to PostgreSQL.
 
 ## Environment Configuration
 

--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+RUN_MIGRATIONS=${RUN_MIGRATIONS:-1}
+
+if [ "$RUN_MIGRATIONS" = "1" ]; then
+  echo "Running database migrations..."
+  alembic -c backend/alembic.ini upgrade head
+else
+  echo "Skipping database migrations (RUN_MIGRATIONS=$RUN_MIGRATIONS)."
+fi
+
+echo "Starting: $*"
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.api
-    command: ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     env_file: .env
     ports:
       - "8000:8000"
@@ -21,6 +20,8 @@ services:
       context: .
       dockerfile: Dockerfile.api
     command: ["celery", "-A", "backend.app.workers.celery_app:celery_app", "worker", "--loglevel=info"]
+    environment:
+      RUN_MIGRATIONS: "0"
     env_file: .env
     depends_on:
       - db


### PR DESCRIPTION
## Summary
- add a backend startup script that runs Alembic migrations before launching the requested process
- update the API image and docker-compose services to invoke the script and skip migrations for the worker
- document the manual Alembic step and login smoke test for local development

## Testing
- not run (documentation and container startup changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d3fc35881483229f2c2936fd306e5e