### PR TITLE
Remove context manager decorator from get_session

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,7 +1,6 @@
 """Database utilities for SQLAlchemy and Alembic."""
 from __future__ import annotations
 
-from contextlib import contextmanager
 from typing import Generator
 
 from sqlalchemy import Engine, create_engine
@@ -22,7 +21,6 @@ SessionLocal = sessionmaker[
 ](bind=ENGINE, autoflush=False, autocommit=False, expire_on_commit=False)
 
 
-@contextmanager
 def get_session() -> Generator[Session, None, None]:
     """Provide a transactional scope around a series of operations."""
 


### PR DESCRIPTION
## Summary
- remove the context manager decorator from `get_session` in `backend/app/core/db.py`
- keep the generator-based session management logic intact while adjusting the imports

## Testing
- `docker compose restart api` *(fails: docker not installed in environment)*
- `docker compose exec api alembic -c backend/alembic.ini upgrade head` *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46a2ea9488322a6f0cba0e218677a