### PR TITLE
Add default namespace auto-assignment on login

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,6 +66,9 @@ class Settings(BaseSettings):
     RATE_LIMIT_INGESTION: str = Field(default="12/minute")
     RATE_LIMIT_CRAWL: str = Field(default="4/hour")
 
+    DEFAULT_NAMESPACE_SLUG: str = Field(default="default")
+    DEFAULT_NAMESPACE_NAME: str | None = Field(default="Default Namespace")
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",


### PR DESCRIPTION
## Summary
- add configuration knobs for the default namespace slug and name
- automatically ensure new users join the configured default namespace during auth
- cover the default namespace flow with integration tests hitting auth/chat/docs endpoints

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d4e50e97d88322909806840711e6c3