### PR TITLE
feat(frontend): load client specific assets

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,14 +4,18 @@ import Home from './components/Home'
 import Callback from './pages/Callback'
 import Login from './pages/Login'
 import ProtectedRoute from './pages/ProtectedRoute'
-import background from '/imgs/background.jpg'
+import { useAuth } from './context/AuthContext'
+import { getClientAssets } from './utils/clientAssets'
 
 export default function App() {
+  const { namespaces } = useAuth()
+  const { background } = getClientAssets(namespaces[0]?.slug)
+
   return (
     <BrowserRouter>
       <div
         className="flex min-h-screen flex-col bg-cover bg-center"
-        style={{ backgroundImage: `url(${background})` }}
+        style={background ? { backgroundImage: `url(${background})` } : undefined}
       >
         <Routes>
           <Route path="/login" element={<Login />} />

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useAuth } from '../context/AuthContext'
 import { apiUrl } from '../utils/api'
-import logo from '/imgs/logo.png'
-import chatbotLogo from '/imgs/chatbot_psy.png'
+import { getClientAssets } from '../utils/clientAssets'
 import QueryInterface from './QueryInterface'
 import ResponseDisplay, {
   type Message as DisplayMessage,
@@ -41,6 +40,8 @@ export default function Home() {
   const [docsLoading, setDocsLoading] = useState(false)
   const [conversationId, setConversationId] = useState<string | null>(null)
   const [selectedSource, setSelectedSource] = useState<Citation | null>(null)
+
+  const { logo, chatbotLogo } = getClientAssets(namespace?.slug ?? namespaces[0]?.slug)
 
   useEffect(() => {
     setNamespaceId((prev) => {
@@ -360,8 +361,8 @@ export default function Home() {
       />
       <header className="mb-6 flex flex-col items-center gap-2 rounded bg-white px-6 py-4 shadow">
         <div className="flex items-center gap-4">
-          <img src={logo} alt="Heidelberg University" className="h-20" />
-          <img src={chatbotLogo} alt="Chatbot Logo" className="h-20" />
+          {logo ? <img src={logo} alt="Client Logo" className="h-20" /> : null}
+          {chatbotLogo ? <img src={chatbotLogo} alt="Chatbot Logo" className="h-20" /> : null}
         </div>
         <h1 className="text-center text-2xl font-semibold">
           IT Chatbot of the Computing Centre of Heidelberg University

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,11 +3,10 @@ import { useNavigate } from 'react-router-dom'
 
 import { useAuth } from '../context/AuthContext'
 import { apiUrl } from '../utils/api'
-
-import chatbotLogo from '/imgs/chatbot_psy.png'
+import { getClientAssets } from '../utils/clientAssets'
 
 export default function Login() {
-  const { user, loading, refresh } = useAuth()
+  const { user, loading, refresh, namespaces } = useAuth()
   const navigate = useNavigate()
   const [email, setEmail] = useState('test@uni-heidelberg.de')
   const [password, setPassword] = useState('')
@@ -57,6 +56,8 @@ export default function Login() {
       setSubmitting(false)
     }
   }
+
+  const { chatbotLogo } = getClientAssets(namespaces[0]?.slug)
 
   return (
     <div className="login-page">

--- a/frontend/src/utils/clientAssets.ts
+++ b/frontend/src/utils/clientAssets.ts
@@ -1,0 +1,60 @@
+type ClientAssets = {
+  background: string | null
+  logo: string | null
+  chatbotLogo: string | null
+}
+
+const DEFAULT_CLIENT_SLUG = 'urz'
+
+const assetModules = import.meta.glob('../../imgs/*/*.{png,jpg,jpeg,JPG,JPEG}', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>
+
+const CLIENT_ASSET_MAP: Record<string, Partial<ClientAssets>> = {}
+
+for (const [fullPath, url] of Object.entries(assetModules)) {
+  const segments = fullPath.split('/')
+  const fileName = segments.pop() ?? ''
+  const clientSlug = segments.pop() ?? ''
+  if (!clientSlug || !fileName) continue
+
+  const extensionIndex = fileName.lastIndexOf('.')
+  if (extensionIndex === -1) continue
+
+  const baseName = fileName.slice(0, extensionIndex).toLowerCase()
+  let key: keyof ClientAssets | null = null
+  if (baseName === 'background') key = 'background'
+  else if (baseName === 'logo') key = 'logo'
+  else if (baseName === 'chatbot_logo') key = 'chatbotLogo'
+
+  if (!key) continue
+
+  const normalizedSlug = clientSlug.toLowerCase()
+  const target = (CLIENT_ASSET_MAP[normalizedSlug] ||= {})
+  target[key] = url
+}
+
+const DEFAULT_ASSETS: ClientAssets = {
+  background: CLIENT_ASSET_MAP[DEFAULT_CLIENT_SLUG]?.background ?? null,
+  logo: CLIENT_ASSET_MAP[DEFAULT_CLIENT_SLUG]?.logo ?? null,
+  chatbotLogo: CLIENT_ASSET_MAP[DEFAULT_CLIENT_SLUG]?.chatbotLogo ?? null,
+}
+
+function mergeAssets(preferred: Partial<ClientAssets> | undefined): ClientAssets {
+  return {
+    background: preferred?.background ?? DEFAULT_ASSETS.background ?? null,
+    logo: preferred?.logo ?? DEFAULT_ASSETS.logo ?? null,
+    chatbotLogo: preferred?.chatbotLogo ?? DEFAULT_ASSETS.chatbotLogo ?? null,
+  }
+}
+
+export function getClientAssets(slug?: string | null): ClientAssets {
+  const normalized = slug?.toLowerCase()
+  if (!normalized) {
+    return mergeAssets(undefined)
+  }
+  return mergeAssets(CLIENT_ASSET_MAP[normalized])
+}
+
+export type { ClientAssets }


### PR DESCRIPTION
## Summary
- add a client asset resolver that maps logo, chatbot logo, and background images per namespace
- update the login, home, and app shells to pick the correct assets for authenticated clients while defaulting to the URZ branding

## Testing
- npm run build *(fails: npm install blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f4faace88322bc805a854cf78987