### PR TITLE
Update default namespace to psychology

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,8 +66,8 @@ class Settings(BaseSettings):
     RATE_LIMIT_INGESTION: str = Field(default="12/minute")
     RATE_LIMIT_CRAWL: str = Field(default="4/hour")
 
-    DEFAULT_NAMESPACE_SLUG: str = Field(default="default")
-    DEFAULT_NAMESPACE_NAME: str | None = Field(default="Default Namespace")
+    DEFAULT_NAMESPACE_SLUG: str = Field(default="psychology")
+    DEFAULT_NAMESPACE_NAME: str | None = Field(default="Psychology")
 
     model_config = {
         "env_file": ".env",


### PR DESCRIPTION
## Summary
- change the default namespace slug and name to Psychology in the backend settings

## Testing
- pytest backend/tests/test_api.py::test_local_login_assigns_default_namespace

------
https://chatgpt.com/codex/tasks/task_e_68d4fc88e52c83228333c69841306fb5