### PR TITLE
Use psychology assets as default client branding

### DIFF
--- a/frontend/src/utils/clientAssets.ts
+++ b/frontend/src/utils/clientAssets.ts
@@ -4,7 +4,7 @@ type ClientAssets = {
   chatbotLogo: string | null
 }
 
-const DEFAULT_CLIENT_SLUG = 'urz'
+const DEFAULT_CLIENT_SLUG = 'psychology'
 
 const assetModules = import.meta.glob('../../imgs/*/*.{png,jpg,jpeg,JPG,JPEG}', {
   eager: true,


### PR DESCRIPTION
## Summary
- default the client asset lookup to the psychology slug so the login page and other views fall back to psychology imagery

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d50b09a848832281b4e2710d486986