### PR TITLE
Fix namespace display fallback to configured name

### DIFF
--- a/backend/app/api/routes_auth.py
+++ b/backend/app/api/routes_auth.py
@@ -118,11 +118,20 @@ async def read_current_user(
         namespace = membership.namespace
         if not namespace:
             continue
+
+        raw_name = (namespace.name or "").strip()
+        if not raw_name or raw_name.lower() == "default namespace":
+            fallback_name = settings.DEFAULT_NAMESPACE_NAME
+            if not fallback_name:
+                slug = (namespace.slug or "").strip()
+                fallback_name = slug.replace("-", " ").title() if slug else None
+            raw_name = fallback_name or "Namespace"
+
         namespaces.append(
             {
                 "id": str(namespace.id),
                 "slug": namespace.slug,
-                "name": namespace.name,
+                "name": raw_name,
                 "role": membership.role,
             }
         )


### PR DESCRIPTION
## Summary
- normalize namespace display names returned by `/auth/me`
- fall back to the configured default namespace name or slug when the stored name is missing or set to "default namespace"

## Testing
- pytest backend/tests/test_api.py::test_local_login_assigns_default_namespace


------
https://chatgpt.com/codex/tasks/task_e_68d50f169fa48322aa6aa8c9e583c5b8