### PR TITLE
Allow configuring public MinIO endpoint for uploads

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     MINIO_ACCESS_KEY: str = Field(default="minioadmin")
     MINIO_SECRET_KEY: str = Field(default="minioadmin")
     MINIO_BUCKET: str = Field(default="rag-data")
+    MINIO_PUBLIC_ENDPOINT: str | None = Field(default=None)
 
     EMBEDDING_MODEL_NAME: str = Field(default="sentence-transformers/all-MiniLM-L6-v2")
     EMBEDDING_DIM: int = Field(default=1536)


### PR DESCRIPTION
## Summary
- add a MINIO_PUBLIC_ENDPOINT setting that lets deployments expose a public MinIO host
- rewrite presigned upload URLs to use the public endpoint when provided
- cover the new behaviour with a dedicated API test

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d52317c154832289df628f5ecc5e9e