### PR TITLE
Install curl in API Docker image

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -5,7 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential gcc && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential gcc curl && rm -rf /var/lib/apt/lists/*
 
 COPY backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
- ensure the API Docker image installs curl alongside other build tools

## Testing
- docker compose build api *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5277b88a48322aac071df895c24f4