### PR TITLE
Prevent document library refresh flicker

### DIFF
--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -52,12 +52,15 @@ export default function Home() {
     })
   }, [namespaces])
 
-  const fetchDocuments = useCallback(async () => {
+  const fetchDocuments = useCallback(async (options: { showLoading?: boolean } = {}) => {
     if (!namespace) {
       setDocuments([])
       return
     }
-    setDocsLoading(true)
+    const shouldShowLoading = options.showLoading ?? documents.length === 0
+    if (shouldShowLoading) {
+      setDocsLoading(true)
+    }
     try {
       const res = await fetch(apiUrl(`/api/docs?namespace_id=${namespace.id}`), { credentials: 'include' })
       if (!res.ok) {
@@ -88,7 +91,7 @@ export default function Home() {
     } finally {
       setDocsLoading(false)
     }
-  }, [namespace])
+  }, [documents.length, namespace])
 
   useEffect(() => {
     if (activeTab !== 'library') return
@@ -379,7 +382,7 @@ export default function Home() {
   }, [csrfToken, documents, fetchDocuments])
 
   const handleRefresh = useCallback(() => {
-    void fetchDocuments()
+    void fetchDocuments({ showLoading: true })
   }, [fetchDocuments])
 
   const handleUploadComplete = useCallback(() => {

--- a/frontend/src/components/Library.tsx
+++ b/frontend/src/components/Library.tsx
@@ -127,7 +127,7 @@ export default function Library({ documents, loading, onRefresh, onDelete, onDel
         </div>
       )}
 
-      {loading && (
+      {loading && documents.length === 0 && (
         <div className="mt-4 text-center text-sm text-gray-500">Loading documents…</div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- gate the document fetch loading state so periodic refreshes keep the table visible
- limit the library loading indicator to the empty-state experience to avoid layout thrashing

## Testing
- Unable to run `npm run build` (missing node_modules because `npm install` fails with 403 from registry)


------
https://chatgpt.com/codex/tasks/task_e_68d534caa6808322be599acfbf27a020