### PR TITLE
Add fallback Ollama host configuration and retry logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ OIDC_CLIENT_ID=changeme
 OIDC_CLIENT_SECRET=changeme
 OIDC_ISSUER=https://example.com/oidc
 OLLAMA_HOST=http://host.docker.internal:11434
+OLLAMA_FALLBACK_HOST=http://127.0.0.1:11434

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The command starts the following services:
 > **Note**
 > Start `ollama serve` (or ensure another Ollama daemon is listening on port 11434) on the
 > host machine before launching Docker Compose. The containers reach it through
-> `http://host.docker.internal:11434`.
+> `http://host.docker.internal:11434`. When you run the API outside Docker, set
+> `OLLAMA_HOST` and `OLLAMA_FALLBACK_HOST` to the addresses that can reach your Ollama runtime.
 
 ### 4. Smoke Test
 
@@ -109,6 +110,7 @@ The following values are the most important when running locally:
 | `OIDC_ISSUER` | Base URL for the OpenID provider | `https://keycloak.local/realms/rag` |
 | `OIDC_REDIRECT_URI` | Backend callback URL | `http://localhost:8000/auth/callback` |
 | `FRONTEND_URL` | Origin used for CORS + redirects | `http://localhost:3000` |
+| `OLLAMA_HOST` / `OLLAMA_FALLBACK_HOST` | Primary + fallback base URLs for the Ollama API | `http://host.docker.internal:11434` / `http://127.0.0.1:11434` |
 | `SESSION_SECRET` | Cookie signing key (keep unique per deployment) | `generate-with-openssl` |
 | `SESSION_COOKIE_SECURE` | Set `false` for plain HTTP dev stacks | `false` |
 | `UPLOAD_MAX_BYTES` | Maximum accepted upload size | `26214400` |

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -46,6 +46,7 @@ class Settings(BaseSettings):
     LOCAL_LOGIN_PASSWORD: str = Field(default="testtest")
 
     OLLAMA_HOST: str = Field(default="http://host.docker.internal:11434")
+    OLLAMA_FALLBACK_HOST: str = Field(default="http://127.0.0.1:11434")
     OLLAMA_MODEL: str = Field(default="gemma3:27b")
     OLLAMA_TIMEOUT: float = Field(default=120.0)
 

--- a/backend/app/rag/ollama_client.py
+++ b/backend/app/rag/ollama_client.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, AsyncIterator, Dict, Optional
 
 import httpx
 
 from ..core.config import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 async def stream_generate(
@@ -25,17 +29,45 @@ async def stream_generate(
     if options:
         payload["options"] = options
 
-    async with httpx.AsyncClient(base_url=settings.OLLAMA_HOST, timeout=settings.OLLAMA_TIMEOUT) as client:
-        async with client.stream("POST", "/api/generate", json=payload) as response:
-            response.raise_for_status()
-            async for line in response.aiter_lines():
-                if not line:
-                    continue
-                try:
-                    data = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                yield data
+    async def _stream_from_host(host: str) -> AsyncIterator[Dict[str, Any]]:
+        async with httpx.AsyncClient(base_url=host, timeout=settings.OLLAMA_TIMEOUT) as client:
+            async with client.stream("POST", "/api/generate", json=payload) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    yield data
+
+    try:
+        async for chunk in _stream_from_host(settings.OLLAMA_HOST):
+            yield chunk
+        return
+    except httpx.TransportError as primary_error:
+        fallback_host = settings.OLLAMA_FALLBACK_HOST
+        should_retry_fallback = fallback_host and fallback_host != settings.OLLAMA_HOST
+        if should_retry_fallback:
+            logger.warning(
+                "Primary Ollama host %s unreachable (%s); retrying with fallback %s",
+                settings.OLLAMA_HOST,
+                primary_error,
+                fallback_host,
+            )
+            try:
+                async for chunk in _stream_from_host(fallback_host):
+                    yield chunk
+                return
+            except httpx.TransportError as fallback_error:
+                logger.warning(
+                    "Fallback Ollama host %s also failed (%s); raising error.",
+                    fallback_host,
+                    fallback_error,
+                )
+                raise fallback_error from primary_error
+        raise primary_error
 
 
 async def complete(prompt: str, *, model: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- add a configurable fallback Ollama host with sensible defaults
- retry stream generation against the fallback host on transport failures and log warnings when both endpoints fail
- document the new environment variables in the README and sample `.env`

## Testing
- curl -sS -X POST http://localhost:8000/api/generate -H 'Content-Type: application/json' -d '{"model":"test","prompt":"ping"}' (fails: connection refused, API not running in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6e56ebd9c83229895fdcef80ec73b