### PR TITLE
Add managed Ollama service to compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ MINIO_BUCKET=rag-data
 OIDC_CLIENT_ID=changeme
 OIDC_CLIENT_SECRET=changeme
 OIDC_ISSUER=https://example.com/oidc
-OLLAMA_HOST=http://host.docker.internal:11434
-OLLAMA_FALLBACK_HOST=http://127.0.0.1:11434
+OLLAMA_HOST=http://ollama:11434
+OLLAMA_FALLBACK_HOST=

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cp .env.example .env
 ```
 
 The defaults target local containers: PostgreSQL with the pgvector extension, Redis, MinIO,
-and expect an Ollama runtime to be available on the Docker host.
+and an Ollama runtime that runs as part of the Docker Compose stack.
 
 ### 2. Build Images
 
@@ -70,13 +70,15 @@ The command starts the following services:
 | `worker`   | Celery worker for async tasks          | n/a  |
 | `db`       | PostgreSQL 16 with pgvector extension  | 5432 |
 | `redis`    | Redis message broker / cache           | 6379 |
+| `ollama`   | Local Ollama runtime with model cache  | 11434 |
 | `minio`    | S3-compatible object storage           | 9000 (API), 9001 (console) |
 
 > **Note**
-> Start `ollama serve` (or ensure another Ollama daemon is listening on port 11434) on the
-> host machine before launching Docker Compose. The containers reach it through
-> `http://host.docker.internal:11434`. When you run the API outside Docker, set
-> `OLLAMA_HOST` and `OLLAMA_FALLBACK_HOST` to the addresses that can reach your Ollama runtime.
+> The Ollama container keeps models under the `ollama-data` named volume. Before chatting for
+> the first time, pull the model configured in `OLLAMA_MODEL` (defaults to `gemma3:27b`) via
+> `docker compose exec ollama ollama pull gemma3:27b`. Adjust the model name to match your
+> configuration. When you run the API outside Docker, set `OLLAMA_HOST` to the address that can
+> reach your Ollama runtime.
 
 ### 4. Smoke Test
 
@@ -110,7 +112,7 @@ The following values are the most important when running locally:
 | `OIDC_ISSUER` | Base URL for the OpenID provider | `https://keycloak.local/realms/rag` |
 | `OIDC_REDIRECT_URI` | Backend callback URL | `http://localhost:8000/auth/callback` |
 | `FRONTEND_URL` | Origin used for CORS + redirects | `http://localhost:3000` |
-| `OLLAMA_HOST` / `OLLAMA_FALLBACK_HOST` | Primary + fallback base URLs for the Ollama API | `http://host.docker.internal:11434` / `http://127.0.0.1:11434` |
+| `OLLAMA_HOST` / `OLLAMA_FALLBACK_HOST` | Base URLs for the Ollama API                     | `http://ollama:11434` / _(leave empty for no fallback)_ |
 | `SESSION_SECRET` | Cookie signing key (keep unique per deployment) | `generate-with-openssl` |
 | `SESSION_COOKIE_SECURE` | Set `false` for plain HTTP dev stacks | `false` |
 | `UPLOAD_MAX_BYTES` | Maximum accepted upload size | `26214400` |

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -45,8 +45,8 @@ class Settings(BaseSettings):
     LOCAL_LOGIN_EMAIL: str = Field(default="test@uni-heidelberg.de")
     LOCAL_LOGIN_PASSWORD: str = Field(default="testtest")
 
-    OLLAMA_HOST: str = Field(default="http://host.docker.internal:11434")
-    OLLAMA_FALLBACK_HOST: str = Field(default="http://127.0.0.1:11434")
+    OLLAMA_HOST: str = Field(default="http://ollama:11434")
+    OLLAMA_FALLBACK_HOST: str | None = Field(default=None)
     OLLAMA_MODEL: str = Field(default="gemma3:27b")
     OLLAMA_TIMEOUT: float = Field(default=120.0)
 

--- a/chatbot/engine.py
+++ b/chatbot/engine.py
@@ -145,7 +145,7 @@ class PatchedOllama(Ollama):
             model_name=self.model,
         )
 
-OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://host.docker.internal:11434")
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")
 
 Settings.llm = PatchedOllama(
     model="gemma3:27b",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,11 @@ services:
     env_file: .env
     ports:
       - "8000:8000"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     depends_on:
       - db
       - redis
       - minio
+      - ollama
     volumes:
       - ./:/app
 
@@ -27,8 +26,7 @@ services:
       - db
       - redis
       - minio
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - ollama
     volumes:
       - ./:/app
 
@@ -59,6 +57,13 @@ services:
     ports:
       - "6379:6379"
 
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+
   minio:
     image: minio/minio:RELEASE.2024-08-03T04-33-23Z
     environment:
@@ -74,3 +79,4 @@ services:
 volumes:
   pgdata:
   minio-data:
+  ollama-data:


### PR DESCRIPTION
## Summary
- add an Ollama service to docker-compose and wire the backend/worker to depend on it
- point default configuration and legacy chatbot engine at the in-cluster Ollama URL
- document the new service and model pull workflow in the README and env template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d78a8f20848322ab998ad8c0ad4b7c